### PR TITLE
2.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>xyz.earthcow.networkjoinmessages</groupId>
     <artifactId>NetworkJoinMessages</artifactId>
     <!-- Version is used in plugin.yml -->
-     <version>2.3.1</version>
+     <version>2.3.2</version>
     <!--<version>dev+${revision}</version>--><!-- To be used with (replace x's) mvn clean package -Drevision=xxx -->
     <packaging>jar</packaging>
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/listeners/PlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/listeners/PlayerListener.java
@@ -7,6 +7,7 @@ import net.md_5.bungee.api.event.ServerConnectEvent;
 import net.md_5.bungee.api.event.ServerConnectedEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import xyz.earthcow.networkjoinmessages.bungee.abstraction.BungeePlayer;
 import xyz.earthcow.networkjoinmessages.bungee.abstraction.BungeeServer;
 import xyz.earthcow.networkjoinmessages.bungee.general.BungeeMain;
 import xyz.earthcow.networkjoinmessages.common.listeners.CorePlayerListener;
@@ -24,17 +25,17 @@ public class PlayerListener implements Listener {
 
         Server server = player.getServer();
         if (server != null) {
-            corePlayerListener.onPreConnect(BungeeMain.getInstance().getOrCreatePlayer(player.getUniqueId()), server.getInfo().getName());
+            corePlayerListener.onPreConnect(BungeeMain.getInstance().getOrPutPlayer(new BungeePlayer(player)), server.getInfo().getName());
         }
     }
 
     @EventHandler
     public void onPlayerSwitchServer(ServerConnectedEvent e) {
-        corePlayerListener.onServerConnected(BungeeMain.getInstance().getOrCreatePlayer(e.getPlayer().getUniqueId()), new BungeeServer(e.getServer().getInfo()), null);
+        corePlayerListener.onServerConnected(BungeeMain.getInstance().getOrPutPlayer(new BungeePlayer(e.getPlayer())), new BungeeServer(e.getServer().getInfo()), null);
     }
 
     @EventHandler
     public void onPostQuit(PlayerDisconnectEvent event) {
-        corePlayerListener.onDisconnect(BungeeMain.getInstance().getOrCreatePlayer(event.getPlayer().getUniqueId()));
+        corePlayerListener.onDisconnect(BungeeMain.getInstance().getOrPutPlayer(new BungeePlayer(event.getPlayer())));
     }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
@@ -29,6 +29,16 @@ public interface CorePlugin {
 
     PlayerManager getPlayerManager();
 
+    default CorePlayer getOrPutPlayer(CorePlayer player) {
+        PlayerManager manager = getPlayerManager();
+        CorePlayer managerPlayer = manager.getPlayer(player.getUniqueId());
+        if (managerPlayer == null) {
+            manager.addPlayer(player);
+            return player;
+        }
+        return managerPlayer;
+    }
+
     default CorePlayer getOrCreatePlayer(UUID uuid) {
         PlayerManager manager = getPlayerManager();
         CorePlayer player = manager.getPlayer(uuid);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/general/VelocityMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/general/VelocityMain.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 @Plugin(
     id = "networkjoinmessages",
     name = "NetworkJoinMessages",
-    version = "2.3.1",
+    version = "2.3.2",
     url = "https://github.com/RagingTech/NetworkJoinMessages",
     description = "A plugin handling join, leave and switch messages for proxy servers.",
     authors = { "EarthCow" },

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/listeners/PlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/listeners/PlayerListener.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import xyz.earthcow.networkjoinmessages.common.listeners.CorePlayerListener;
+import xyz.earthcow.networkjoinmessages.velocity.abstraction.VelocityPlayer;
 import xyz.earthcow.networkjoinmessages.velocity.abstraction.VelocityServer;
 import xyz.earthcow.networkjoinmessages.velocity.general.VelocityMain;
 
@@ -18,17 +19,17 @@ public class PlayerListener {
             return;
         }
 
-        corePlayerListener.onPreConnect(VelocityMain.getInstance().getOrCreatePlayer(event.getPlayer().getUniqueId()), event.getPreviousServer().getServerInfo().getName());
+        corePlayerListener.onPreConnect(VelocityMain.getInstance().getOrPutPlayer(new VelocityPlayer(event.getPlayer())), event.getPreviousServer().getServerInfo().getName());
     }
 
     @Subscribe
     public void onServerConnected(ServerConnectedEvent event) {
         VelocityServer previousServer = event.getPreviousServer().isPresent() ? new VelocityServer(event.getPreviousServer().get()) : null;
-        corePlayerListener.onServerConnected(VelocityMain.getInstance().getOrCreatePlayer(event.getPlayer().getUniqueId()), new VelocityServer(event.getServer()), previousServer);
+        corePlayerListener.onServerConnected(VelocityMain.getInstance().getOrPutPlayer(new VelocityPlayer(event.getPlayer())), new VelocityServer(event.getServer()), previousServer);
     }
 
     @Subscribe
     public void onDisconnect(DisconnectEvent event) {
-        corePlayerListener.onDisconnect(VelocityMain.getInstance().getOrCreatePlayer(event.getPlayer().getUniqueId()));
+        corePlayerListener.onDisconnect(VelocityMain.getInstance().getOrPutPlayer(new VelocityPlayer(event.getPlayer())));
     }
 }


### PR DESCRIPTION
Fixes a bug where the Velocity/Bungee player object inside of a CorePlayer would be null. This would occur during failed connections because the player would never join the proxy. Solution was to create a new CorePlugin#getOrPutPlayer method specifically for network events. Hypothetically, should only be necessary for the PreConnection event, but utilizing it for each event just to be safe for now.