### PR TITLE
Adds vanish user notifications and respect PV vanish level options

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/abstraction/BungeePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/abstraction/BungeePlayer.java
@@ -19,6 +19,8 @@ public class BungeePlayer implements CorePlayer {
     private String cachedLeaveMessage;
     private boolean disconnecting = false;
     private boolean premiumVanishHidden = false;
+    private int pvUseLevel = 0;
+    private int pvSeeLevel = 0;
 
     public BungeePlayer(ProxiedPlayer bungeePlayer) {
         this.bungeePlayer = bungeePlayer;
@@ -103,9 +105,26 @@ public class BungeePlayer implements CorePlayer {
     public boolean getPremiumVanishHidden() {
         return premiumVanishHidden;
     }
-
     @Override
     public void setPremiumVanishHidden(boolean premiumVanishHidden) {
         this.premiumVanishHidden = premiumVanishHidden;
+    }
+
+    @Override
+    public int getPremiumVanishUseLevel() {
+        return pvUseLevel;
+    }
+    @Override
+    public void setPremiumVanishUseLevel(int pvUseLevel) {
+        this.pvUseLevel = pvUseLevel;
+    }
+
+    @Override
+    public int getPremiumVanishSeeLevel() {
+        return pvSeeLevel;
+    }
+    @Override
+    public void setPremiumVanishSeeLevel(int pvSeeLevel) {
+        this.pvSeeLevel = pvSeeLevel;
     }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/Core.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/Core.java
@@ -81,7 +81,7 @@ public class Core {
 
         // Message building
         MessageFormatter messageFormatter = new MessageFormatter(plugin, config, sayanVanishHook);
-        ReceiverResolver receiverResolver  = new ReceiverResolver(plugin, config);
+        ReceiverResolver receiverResolver  = new ReceiverResolver(plugin, config, sayanVanishHook != null, premiumVanish != null);
         MessageHandler   messageHandler    = new MessageHandler(plugin, config, stateStore, placeholderResolver, receiverResolver);
 
         // Player event helpers

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
@@ -127,15 +127,18 @@ public final class MessageHandler {
     }
 
     public void broadcastSilentMessage(
-            @NotNull String text, @NotNull MessageType type,
-            @NotNull String from, @NotNull String to,
-            @NotNull CorePlayer triggerPlayer,
-            boolean isParseTarget
+        @NotNull String text, @NotNull MessageType type,
+        @NotNull String from, @NotNull String to,
+        @NotNull CorePlayer triggerPlayer,
+        boolean isParseTarget
     ) {
         sendSilentConsoleMessage(type, from, to, triggerPlayer);
 
-        for (CorePlayer player : receiverResolver.getSilentReceivers(triggerPlayer)) {
-            sendMessage(player, config.getSilentPrefix() + text, isParseTarget ? triggerPlayer : null);
+        CorePlayer parseTarget = isParseTarget ? triggerPlayer : null;
+
+        for (CorePlayer player : plugin.getAllPlayers()) {
+            if (!receiverResolver.isSilentReceiver(player, triggerPlayer)) continue;
+            sendMessage(player, config.getSilentPrefix() + text, parseTarget);
         }
     }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
@@ -98,11 +98,11 @@ public final class MessageHandler {
     public void broadcastMessage(
             String text, MessageType type,
             String from, String to,
-            @Nullable CorePlayer parseTarget,
+            @NotNull CorePlayer parseTarget,
             boolean silent
     ) {
         if (silent) {
-            broadcastSilentMessage(text, type, from, to, parseTarget);
+            broadcastSilentMessage(text, type, from, to, parseTarget, true);
             return;
         }
 
@@ -126,15 +126,16 @@ public final class MessageHandler {
         }
     }
 
-    private void broadcastSilentMessage(
+    public void broadcastSilentMessage(
             @NotNull String text, @NotNull MessageType type,
             @NotNull String from, @NotNull String to,
-            @Nullable CorePlayer parseTarget
+            @NotNull CorePlayer triggerPlayer,
+            boolean isParseTarget
     ) {
-        sendSilentConsoleMessage(type, from, to, parseTarget);
+        sendSilentConsoleMessage(type, from, to, triggerPlayer);
 
-        for (CorePlayer player : receiverResolver.getSilentReceivers(parseTarget)) {
-            sendMessage(player, config.getSilentPrefix() + text, parseTarget);
+        for (CorePlayer player : receiverResolver.getSilentReceivers(triggerPlayer)) {
+            sendMessage(player, config.getSilentPrefix() + text, isParseTarget ? triggerPlayer : null);
         }
     }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
@@ -9,7 +9,6 @@ import xyz.earthcow.networkjoinmessages.common.broadcast.ReceiverResolver;
 import xyz.earthcow.networkjoinmessages.common.config.PluginConfig;
 import xyz.earthcow.networkjoinmessages.common.player.PlayerStateStore;
 import xyz.earthcow.networkjoinmessages.common.util.Formatter;
-import xyz.earthcow.networkjoinmessages.common.MessageType;
 import xyz.earthcow.networkjoinmessages.common.util.PlaceholderResolver;
 
 import java.util.*;
@@ -134,12 +133,8 @@ public final class MessageHandler {
     ) {
         sendSilentConsoleMessage(type, from, to, parseTarget);
 
-        if (!config.isNotifyAdminsOnSilentMove()) return;
-
-        for (CorePlayer player : plugin.getAllPlayers()) {
-            if (player.hasPermission("networkjoinmessages.silent")) {
-                sendMessage(player, config.getSilentPrefix() + text, parseTarget);
-            }
+        for (CorePlayer player : receiverResolver.getSilentReceivers(parseTarget)) {
+            sendMessage(player, config.getSilentPrefix() + text, parseTarget);
         }
     }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
@@ -33,4 +33,8 @@ public interface CorePlayer extends CoreCommandSender {
 
     boolean getPremiumVanishHidden();
     void setPremiumVanishHidden(boolean premiumVanishHidden);
+    int getPremiumVanishUseLevel();
+    void setPremiumVanishUseLevel(int level);
+    int getPremiumVanishSeeLevel();
+    void setPremiumVanishSeeLevel(int level);
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
@@ -84,7 +84,7 @@ public final class ReceiverResolver {
     }
 
     /**
-     * Collects and returns all the {@link CorePlayer}s who should receive silent messages.<br>
+     * Determines if a player should receive a silent message.<br>
      * A player will receive a silent message if any one of the following is true:
      * <ol>
      *     <li>If {@code NotifyAdminsOnSilentMove} is enabled and the player holds the
@@ -94,28 +94,18 @@ public final class ReceiverResolver {
      *     <li>If PremiumVanish is present, {@code PVNotifyVanishEnabledPlayersOnSilentMove} is true, and the player's
      *     {@code pv.see} level is the same as or greater than the trigger player's {@code pv.use} level</li>
      * </ol>
+     * @param player        The player to determine whether they are a silent receiver or not
      * @param triggerPlayer The player who triggered a message
-     * @return The list of players who should receive the silent message
+     * @return              Whether the player is a silent receiver (true) or not (false)
      */
-    public List<CorePlayer> getSilentReceivers(@NotNull CorePlayer triggerPlayer) {
-        List<CorePlayer> silentReceivers = new ArrayList<>();
-
-        for (CorePlayer player : plugin.getAllPlayers()) {
-            if (config.isNotifyAdminsOnSilentMove() && player.hasPermission("networkjoinmessages.silent")) {
-                silentReceivers.add(player);
-                continue;
-            }
-            if (hasSayanVanish && config.isSVNotifyVanishEnabledPlayersOnSilentMove()
-                && player.hasPermission("sayanvanish.vanish.use")) {
-                silentReceivers.add(player);
-                continue;
-            }
-            if (hasPremiumVanish && config.isPVNotifyVanishEnabledPlayersOnSilentMove()
-                && (player.getPremiumVanishSeeLevel() >= triggerPlayer.getPremiumVanishUseLevel())) {
-                silentReceivers.add(player);
-            }
-        }
-        return silentReceivers;
+    public boolean isSilentReceiver(@NotNull CorePlayer player, @NotNull CorePlayer triggerPlayer) {
+        if (config.isNotifyAdminsOnSilentMove() && player.hasPermission("networkjoinmessages.silent"))
+            return true;
+        if (hasSayanVanish && config.isSVNotifyVanishEnabledPlayersOnSilentMove()
+            && player.hasPermission("sayanvanish.vanish.use"))
+            return true;
+        return hasPremiumVanish && config.isPVNotifyVanishEnabledPlayersOnSilentMove()
+            && player.getPremiumVanishSeeLevel() >= triggerPlayer.getPremiumVanishUseLevel();
     }
 
     // --- Blacklist / whitelist checks ---

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
@@ -91,8 +91,14 @@ public final class ReceiverResolver {
      *     {@code networkjoinmessages.silent} permission</li>
      *     <li>If SayanVanish is present, {@code SVNotifyVanishEnabledPlayersOnSilentMove} is true, and the player holds
      *     the {@code sayanvanish.vanish.use} permission</li>
-     *     <li>If PremiumVanish is present, {@code PVNotifyVanishEnabledPlayersOnSilentMove} is true, and the player's
-     *     {@code pv.see} level is the same as or greater than the trigger player's {@code pv.use} level</li>
+     *     <li>If PremiumVanish is present, {@code PVNotifyVanishEnabledPlayersOnSilentMove} is true, then if
+     *     {@code PVNotifyRespectVanishLevels}:
+     *     <ul>
+     *         <li><b>Is true</b> and the player's {@code pv.see} level is the same as or greater than the trigger player's
+     *         {@code pv.use} level</li>
+     *         <li><b>Is false</b> and the player holds either {@code pv.use} or {@code pv.see}</li>
+     *     </ul>
+     *     </li>
      * </ol>
      * @param player        The player to determine whether they are a silent receiver or not
      * @param triggerPlayer The player who triggered a message
@@ -104,8 +110,14 @@ public final class ReceiverResolver {
         if (hasSayanVanish && config.isSVNotifyVanishEnabledPlayersOnSilentMove()
             && player.hasPermission("sayanvanish.vanish.use"))
             return true;
-        return hasPremiumVanish && config.isPVNotifyVanishEnabledPlayersOnSilentMove()
-            && player.getPremiumVanishSeeLevel() >= triggerPlayer.getPremiumVanishUseLevel();
+        if (hasPremiumVanish && config.isPVNotifyVanishEnabledPlayersOnSilentMove()) {
+            if (config.isPVNotifyRespectVanishLevels()) {
+                if (player.getPremiumVanishSeeLevel() >= triggerPlayer.getPremiumVanishUseLevel())
+                    return true;
+            }
+            return (player.hasPermission("pv.use") || player.hasPermission("pv.see"));
+        }
+        return false;
     }
 
     // --- Blacklist / whitelist checks ---

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/broadcast/ReceiverResolver.java
@@ -1,5 +1,6 @@
 package xyz.earthcow.networkjoinmessages.common.broadcast;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CoreBackendServer;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
@@ -18,10 +19,15 @@ public final class ReceiverResolver {
 
     private final CorePlugin plugin;
     private final PluginConfig config;
+    private final boolean hasSayanVanish;
+    private final boolean hasPremiumVanish;
 
-    public ReceiverResolver(CorePlugin plugin, PluginConfig config) {
+
+    public ReceiverResolver(CorePlugin plugin, PluginConfig config, boolean hasSayanVanish, boolean hasPremiumVanish) {
         this.plugin = plugin;
         this.config = config;
+        this.hasSayanVanish = hasSayanVanish;
+        this.hasPremiumVanish = hasPremiumVanish;
     }
 
     // --- Audience resolution ---
@@ -75,6 +81,41 @@ public final class ReceiverResolver {
         if (viewableByJoined && toServer != null)   receivers.addAll(getServerPlayers(toServer));
         if (viewableByLeft   && fromServer != null) receivers.addAll(getServerPlayers(fromServer));
         return receivers;
+    }
+
+    /**
+     * Collects and returns all the {@link CorePlayer}s who should receive silent messages.<br>
+     * A player will receive a silent message if any one of the following is true:
+     * <ol>
+     *     <li>If {@code NotifyAdminsOnSilentMove} is enabled and the player holds the
+     *     {@code networkjoinmessages.silent} permission</li>
+     *     <li>If SayanVanish is present, {@code SVNotifyVanishEnabledPlayersOnSilentMove} is true, and the player holds
+     *     the {@code sayanvanish.vanish.use} permission</li>
+     *     <li>If PremiumVanish is present, {@code PVNotifyVanishEnabledPlayersOnSilentMove} is true, and the player's
+     *     {@code pv.see} level is the same as or greater than the trigger player's {@code pv.use} level</li>
+     * </ol>
+     * @param triggerPlayer The player who triggered a message
+     * @return The list of players who should receive the silent message
+     */
+    public List<CorePlayer> getSilentReceivers(@NotNull CorePlayer triggerPlayer) {
+        List<CorePlayer> silentReceivers = new ArrayList<>();
+
+        for (CorePlayer player : plugin.getAllPlayers()) {
+            if (config.isNotifyAdminsOnSilentMove() && player.hasPermission("networkjoinmessages.silent")) {
+                silentReceivers.add(player);
+                continue;
+            }
+            if (hasSayanVanish && config.isSVNotifyVanishEnabledPlayersOnSilentMove()
+                && player.hasPermission("sayanvanish.vanish.use")) {
+                silentReceivers.add(player);
+                continue;
+            }
+            if (hasPremiumVanish && config.isPVNotifyVanishEnabledPlayersOnSilentMove()
+                && (player.getPremiumVanishSeeLevel() >= triggerPlayer.getPremiumVanishUseLevel())) {
+                silentReceivers.add(player);
+            }
+        }
+        return silentReceivers;
     }
 
     // --- Blacklist / whitelist checks ---

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/config/PluginConfig.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/config/PluginConfig.java
@@ -126,6 +126,7 @@ public final class PluginConfig {
     @Getter private boolean PVSpoofLeaveMessageOnHide;
     @Getter private boolean PVTreatVanishedOnJoin;
     @Getter private boolean PVNotifyVanishEnabledPlayersOnSilentMove;
+    @Getter private boolean PVNotifyRespectVanishLevels;
     @Getter private boolean shouldSuppressLimboSwap;
     @Getter private boolean shouldSuppressLimboJoin;
     @Getter private boolean shouldSuppressLimboLeave;
@@ -231,6 +232,7 @@ public final class PluginConfig {
         PVSpoofLeaveMessageOnHide                = config.getBoolean("OtherPlugins.PremiumVanish.SpoofLeaveMessageOnHide");
         PVTreatVanishedOnJoin                    = config.getBoolean("OtherPlugins.PremiumVanish.TreatVanishedOnJoin");
         PVNotifyVanishEnabledPlayersOnSilentMove = config.getBoolean("OtherPlugins.PremiumVanish.NotifyVanishEnabledPlayersOnSilentMove");
+        PVNotifyRespectVanishLevels              = config.getBoolean("OtherPlugins.PremiumVanish.NotifyRespectVanishLevels");
         shouldSuppressLimboSwap                  = config.getBoolean("OtherPlugins.LimboAPI.SuppressSwapMessages");
         shouldSuppressLimboJoin                  = config.getBoolean("OtherPlugins.LimboAPI.SuppressJoinMessages");
         shouldSuppressLimboLeave                 = config.getBoolean("OtherPlugins.LimboAPI.SuppressLeaveMessages");

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/config/PluginConfig.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/config/PluginConfig.java
@@ -119,11 +119,13 @@ public final class PluginConfig {
     // Third-party plugin integration flags
     @Getter private boolean SVTreatVanishedPlayersAsSilent;
     @Getter private boolean SVRemoveVanishedPlayersFromPlayerCount;
+    @Getter private boolean SVNotifyVanishEnabledPlayersOnSilentMove;
     @Getter private boolean PVTreatVanishedPlayersAsSilent;
     @Getter private boolean PVRemoveVanishedPlayersFromPlayerCount;
     @Getter private boolean PVSpoofJoinMessageOnShow;
     @Getter private boolean PVSpoofLeaveMessageOnHide;
     @Getter private boolean PVTreatVanishedOnJoin;
+    @Getter private boolean PVNotifyVanishEnabledPlayersOnSilentMove;
     @Getter private boolean shouldSuppressLimboSwap;
     @Getter private boolean shouldSuppressLimboJoin;
     @Getter private boolean shouldSuppressLimboLeave;
@@ -219,17 +221,19 @@ public final class PluginConfig {
         serverJoinMessageDisabled      = config.getStringList("Settings.IgnoreJoinMessagesList");
         serverLeaveMessageDisabled     = config.getStringList("Settings.IgnoreLeaveMessagesList");
 
-        PPBRequestTimeout                      = config.getLong("OtherPlugins.PAPIProxyBridge.RequestTimeout");
-        SVTreatVanishedPlayersAsSilent         = config.getBoolean("OtherPlugins.SayanVanish.TreatVanishedPlayersAsSilent");
-        SVRemoveVanishedPlayersFromPlayerCount = config.getBoolean("OtherPlugins.SayanVanish.RemoveVanishedPlayersFromPlayerCount");
-        PVTreatVanishedPlayersAsSilent         = config.getBoolean("OtherPlugins.PremiumVanish.TreatVanishedPlayersAsSilent");
-        PVRemoveVanishedPlayersFromPlayerCount = config.getBoolean("OtherPlugins.PremiumVanish.RemoveVanishedPlayersFromPlayerCount");
-        PVSpoofJoinMessageOnShow               = config.getBoolean("OtherPlugins.PremiumVanish.SpoofJoinMessageOnShow");
-        PVSpoofLeaveMessageOnHide              = config.getBoolean("OtherPlugins.PremiumVanish.SpoofLeaveMessageOnHide");
-        PVTreatVanishedOnJoin                  = config.getBoolean("OtherPlugins.PremiumVanish.TreatVanishedOnJoin");
-        shouldSuppressLimboSwap                = config.getBoolean("OtherPlugins.LimboAPI.SuppressSwapMessages");
-        shouldSuppressLimboJoin                = config.getBoolean("OtherPlugins.LimboAPI.SuppressJoinMessages");
-        shouldSuppressLimboLeave               = config.getBoolean("OtherPlugins.LimboAPI.SuppressLeaveMessages");
+        PPBRequestTimeout                        = config.getLong("OtherPlugins.PAPIProxyBridge.RequestTimeout");
+        SVTreatVanishedPlayersAsSilent           = config.getBoolean("OtherPlugins.SayanVanish.TreatVanishedPlayersAsSilent");
+        SVRemoveVanishedPlayersFromPlayerCount   = config.getBoolean("OtherPlugins.SayanVanish.RemoveVanishedPlayersFromPlayerCount");
+        SVNotifyVanishEnabledPlayersOnSilentMove = config.getBoolean("OtherPlugins.SayanVanish.NotifyVanishEnabledPlayersOnSilentMove");
+        PVTreatVanishedPlayersAsSilent           = config.getBoolean("OtherPlugins.PremiumVanish.TreatVanishedPlayersAsSilent");
+        PVRemoveVanishedPlayersFromPlayerCount   = config.getBoolean("OtherPlugins.PremiumVanish.RemoveVanishedPlayersFromPlayerCount");
+        PVSpoofJoinMessageOnShow                 = config.getBoolean("OtherPlugins.PremiumVanish.SpoofJoinMessageOnShow");
+        PVSpoofLeaveMessageOnHide                = config.getBoolean("OtherPlugins.PremiumVanish.SpoofLeaveMessageOnHide");
+        PVTreatVanishedOnJoin                    = config.getBoolean("OtherPlugins.PremiumVanish.TreatVanishedOnJoin");
+        PVNotifyVanishEnabledPlayersOnSilentMove = config.getBoolean("OtherPlugins.PremiumVanish.NotifyVanishEnabledPlayersOnSilentMove");
+        shouldSuppressLimboSwap                  = config.getBoolean("OtherPlugins.LimboAPI.SuppressSwapMessages");
+        shouldSuppressLimboJoin                  = config.getBoolean("OtherPlugins.LimboAPI.SuppressJoinMessages");
+        shouldSuppressLimboLeave                 = config.getBoolean("OtherPlugins.LimboAPI.SuppressLeaveMessages");
 
         plugin.getCoreLogger().setDebug(config.getBoolean("debug"));
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -121,7 +121,7 @@ public class CorePlayerListener {
 
         PremiumVanish pv = plugin.getVanishAPI();
         if (pv != null) {
-            if (config.isPVNotifyVanishEnabledPlayersOnSilentMove()) {
+            if (config.isPVNotifyVanishEnabledPlayersOnSilentMove() && config.isPVNotifyRespectVanishLevels()) {
                 PremiumVanishLevelUtil.updateVanishLevels(player);
             }
             if (pv.isVanished(player.getUniqueId())) {

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -16,6 +16,7 @@ import xyz.earthcow.networkjoinmessages.common.util.Formatter;
 import xyz.earthcow.networkjoinmessages.common.storage.PlayerJoinTracker;
 import xyz.earthcow.networkjoinmessages.common.MessageType;
 import xyz.earthcow.networkjoinmessages.common.util.PlaceholderResolver;
+import xyz.earthcow.networkjoinmessages.common.util.PremiumVanishLevelUtil;
 
 /**
  * Routes platform-level player events (join, swap, disconnect) to the appropriate handlers.
@@ -119,8 +120,13 @@ public class CorePlayerListener {
         player.setLastKnownConnectedServer(server);
 
         PremiumVanish pv = plugin.getVanishAPI();
-        if (pv != null && pv.isVanished(player.getUniqueId())) {
-            player.setPremiumVanishHidden(true);
+        if (pv != null) {
+            if (config.isPVNotifyVanishEnabledPlayersOnSilentMove()) {
+                PremiumVanishLevelUtil.updateVanishLevels(player);
+            }
+            if (pv.isVanished(player.getUniqueId())) {
+                player.setPremiumVanishHidden(true);
+            }
         }
 
         leaveMessageCache.refresh(player);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -172,7 +172,7 @@ public class CorePlayerListener {
         boolean silent = silenceChecker.isSilent(player);
         String serverName = player.getCurrentServer().getName();
 
-        // Pass null as parseTarget — player is gone, placeholders already resolved in cache
+        // Pass player as triggerPlayer but false for isParseTarget as the placeholders are already resolved in cache
         messageHandler.broadcastSilentMessage(message, MessageType.LEAVE, serverName, "", player, false);
         fireLeaveEvent(player, serverName, message, silent);
     }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -173,7 +173,7 @@ public class CorePlayerListener {
         String serverName = player.getCurrentServer().getName();
 
         // Pass null as parseTarget — player is gone, placeholders already resolved in cache
-        messageHandler.broadcastMessage(message, MessageType.LEAVE, serverName, "", null, silent);
+        messageHandler.broadcastSilentMessage(message, MessageType.LEAVE, serverName, "", player, false);
         fireLeaveEvent(player, serverName, message, silent);
     }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/util/PremiumVanishLevelUtil.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/util/PremiumVanishLevelUtil.java
@@ -1,0 +1,40 @@
+package xyz.earthcow.networkjoinmessages.common.util;
+
+import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
+
+public final class PremiumVanishLevelUtil {
+
+    private static final int MAX_LEVEL = 100;
+
+    /**
+     * Determines a player's vanish level by scanning down from {@link PremiumVanishLevelUtil#MAX_LEVEL} to obtain
+     * their highest level
+     * @param player The player to analyze
+     * @param forUse If {@code true}, we use {@code pv.use} otherwise we use {@code pv.see}
+     * @return The determined highest vanish level for the specified player
+     */
+    private static int determineVanishLevel(CorePlayer player, boolean forUse) {
+        String base = forUse ? "pv.use" : "pv.see";
+        String prefix = base + ".level";
+        for (int i = MAX_LEVEL; i >= 1; i--) {
+            if (player.hasPermission(prefix + i)) {
+                return i;
+            }
+        }
+        // The base permission (pv.use or pv.see) is a level of 1
+        return player.hasPermission(base) ? 1 : 0;
+    }
+
+    /**
+     * Updates a player's PremiumVanish use and see vanish levels. Uses
+     * {@link PremiumVanishLevelUtil#determineVanishLevel(CorePlayer, boolean)} to do so. The logic is unpreventably
+     * costly as it iterates down from {@link PremiumVanishLevelUtil#MAX_LEVEL} checking player permission each time.
+     * <b>Should be called asynchronously to the main thread.</b>
+     * @param player The player in which vanish levels will be updated for
+     */
+    public static void updateVanishLevels(CorePlayer player) {
+        player.setPremiumVanishUseLevel(determineVanishLevel(player, true));
+        player.setPremiumVanishSeeLevel(determineVanishLevel(player, false));
+    }
+
+}

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/abstraction/VelocityPlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/abstraction/VelocityPlayer.java
@@ -20,6 +20,8 @@ public class VelocityPlayer implements CorePlayer {
     private String cachedLeaveMessage;
     private boolean disconnecting = false;
     private boolean premiumVanishHidden = false;
+    private int pvUseLevel = 0;
+    private int pvSeeLevel = 0;
 
     public VelocityPlayer(Player velocityPlayer) {
         this.velocityPlayer = velocityPlayer;
@@ -115,5 +117,23 @@ public class VelocityPlayer implements CorePlayer {
     @Override
     public void setPremiumVanishHidden(boolean premiumVanishHidden) {
         this.premiumVanishHidden = premiumVanishHidden;
+    }
+
+    @Override
+    public int getPremiumVanishUseLevel() {
+        return pvUseLevel;
+    }
+    @Override
+    public void setPremiumVanishUseLevel(int pvUseLevel) {
+        this.pvUseLevel = pvUseLevel;
+    }
+
+    @Override
+    public int getPremiumVanishSeeLevel() {
+        return pvSeeLevel;
+    }
+    @Override
+    public void setPremiumVanishSeeLevel(int pvSeeLevel) {
+        this.pvSeeLevel = pvSeeLevel;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -244,6 +244,8 @@ OtherPlugins:
     TreatVanishedPlayersAsSilent: true
     # Vanished players will not be counted in the player count placeholders
     RemoveVanishedPlayersFromPlayerCount: true
+    # Send silenced messages to players with the permission sayanvanish.vanish.use (permission must be set on the proxy)
+    NotifyVanishEnabledPlayersOnSilentMove: false
   PremiumVanish:
     # Vanished players will not trigger messages aside from
     # silent messages sent to players with networkjoinmessages.silent permission
@@ -257,6 +259,9 @@ OtherPlugins:
     # Treats a player with the permission pv.joinvanished as vanished on join (permission must be set on the proxy)
     # This is to be used in conjunction with the PremiumVanish 'AutoVanishOnJoin' option
     TreatVanishedOnJoin: false
+    # Send silenced messages to players with the permission pv.see[.levelX] (permission must be set on the proxy)
+    # Requires players to rejoin upon changes to their level or setting this setting to true
+    NotifyVanishEnabledPlayersOnSilentMove: false
   LimboAPI:
     # No swap messages for players swapping to or from limbo servers
     SuppressSwapMessages: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -276,4 +276,4 @@ OtherPlugins:
 
 debug: false
 # Do not touch this
-config-version: 13
+config-version: 14

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -244,7 +244,7 @@ OtherPlugins:
     TreatVanishedPlayersAsSilent: true
     # Vanished players will not be counted in the player count placeholders
     RemoveVanishedPlayersFromPlayerCount: true
-    # Send silenced messages to players with the permission sayanvanish.vanish.use (permission must be set on the proxy)
+    # Send silent messages to players with the permission sayanvanish.vanish.use (permission must be set on the proxy)
     NotifyVanishEnabledPlayersOnSilentMove: false
   PremiumVanish:
     # Vanished players will not trigger messages aside from
@@ -259,9 +259,13 @@ OtherPlugins:
     # Treats a player with the permission pv.joinvanished as vanished on join (permission must be set on the proxy)
     # This is to be used in conjunction with the PremiumVanish 'AutoVanishOnJoin' option
     TreatVanishedOnJoin: false
-    # Send silenced messages to players with the permission pv.see[.levelX] (permission must be set on the proxy)
-    # Requires players to rejoin upon changes to their level or setting this setting to true
+    # Send silent messages to players with the permission pv.use or pv.see (permission must be set on the proxy)
     NotifyVanishEnabledPlayersOnSilentMove: false
+    # Instead of sending silent messages to all players with pv.use or pv.see, only send silent messages to players with
+    # a greater than or equal to see level than the player who triggered the message's use level.
+    # Simply put, this setting respects the layered use/see permissions set with PremiumVanish.
+    # Requires players to rejoin upon changes to their level or setting this setting to true
+    NotifyRespectVanishLevels: false
   LimboAPI:
     # No swap messages for players swapping to or from limbo servers
     SuppressSwapMessages: true


### PR DESCRIPTION
Adds three configuration options and their related functionality:
- `SayanVanish.NotifyVanishEnabledPlayersOnSilentMove`: Send silent messages to players with the `sayanvanish.vanish.use` permission.
- `PremiumVanish.NotifyVanishEnabledPlayersOnSilentMove`: Send silent messages to players with the `pv.use` or `pv.see` permissions.
- `PremiumVanish.NotifyRespectVanishLevels`: Requires `PremiumVanish.NotifyVanishEnabledPlayersOnSilentMove` and will respect PremiumVanish layered vanish level permissions. This means only players with a `pv.see.levelX` greater than or equal to the player who triggered the message's `pv.use.levelX` will receive the message.

Duplicate logic was added to both `CorePlayer` implementations (`BungeePlayer` & `VelocityPlayer`) but this will be resolved/removed after implementing #55.