### PR TITLE
Makes CorePlayer an abstract class

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/abstraction/BungeePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/abstraction/BungeePlayer.java
@@ -12,19 +12,13 @@ import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
 
 import java.util.UUID;
 
-public class BungeePlayer implements CorePlayer {
+public class BungeePlayer extends CorePlayer {
     private final ProxiedPlayer bungeePlayer;
-    private CoreBackendServer lastKnownConnectedServer;
     private final Audience audience;
-    private String cachedLeaveMessage;
-    private boolean disconnecting = false;
-    private boolean premiumVanishHidden = false;
-    private int pvUseLevel = 0;
-    private int pvSeeLevel = 0;
 
     public BungeePlayer(ProxiedPlayer bungeePlayer) {
+        super(new BungeeServer(bungeePlayer.getServer().getInfo()));
         this.bungeePlayer = bungeePlayer;
-        this.lastKnownConnectedServer = new BungeeServer(bungeePlayer.getServer().getInfo());
         this.audience = BungeeMain.getInstance().getAudiences().player(bungeePlayer);
     }
 
@@ -58,19 +52,9 @@ public class BungeePlayer implements CorePlayer {
     public @Nullable CoreBackendServer getCurrentServer() {
         Server server = bungeePlayer.getServer();
         if (server == null) {
-            return lastKnownConnectedServer;
+            return getLastKnownConnectedServer();
         }
         return new BungeeServer(server.getInfo());
-    }
-
-    @Override
-    public @Nullable CoreBackendServer getLastKnownConnectedServer() {
-        return lastKnownConnectedServer;
-    }
-
-    @Override
-    public void setLastKnownConnectedServer(CoreBackendServer server) {
-        lastKnownConnectedServer = server;
     }
 
     @Override
@@ -81,50 +65,5 @@ public class BungeePlayer implements CorePlayer {
     @Override
     public boolean isInLimbo() {
         return false;
-    }
-
-    @Override
-    public String getCachedLeaveMessage() {
-        return cachedLeaveMessage;
-    }
-    @Override
-    public void setCachedLeaveMessage(String cachedLeaveMessage) {
-        this.cachedLeaveMessage = cachedLeaveMessage;
-    }
-
-    @Override
-    public boolean isDisconnecting() {
-        return disconnecting;
-    }
-    @Override
-    public void setDisconnecting() {
-        this.disconnecting = true;
-    }
-
-    @Override
-    public boolean getPremiumVanishHidden() {
-        return premiumVanishHidden;
-    }
-    @Override
-    public void setPremiumVanishHidden(boolean premiumVanishHidden) {
-        this.premiumVanishHidden = premiumVanishHidden;
-    }
-
-    @Override
-    public int getPremiumVanishUseLevel() {
-        return pvUseLevel;
-    }
-    @Override
-    public void setPremiumVanishUseLevel(int pvUseLevel) {
-        this.pvUseLevel = pvUseLevel;
-    }
-
-    @Override
-    public int getPremiumVanishSeeLevel() {
-        return pvSeeLevel;
-    }
-    @Override
-    public void setPremiumVanishSeeLevel(int pvSeeLevel) {
-        this.pvSeeLevel = pvSeeLevel;
     }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
@@ -1,40 +1,34 @@
 package xyz.earthcow.networkjoinmessages.common.abstraction;
 
+import lombok.Getter;
+import lombok.Setter;
 import net.kyori.adventure.audience.Audience;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
 
-public interface CorePlayer extends CoreCommandSender {
+@Getter @Setter
+public abstract class CorePlayer implements CoreCommandSender {
+    // Fields
+    private CoreBackendServer lastKnownConnectedServer;
+    private boolean disconnecting = false;
+    private String cachedLeaveMessage;
+    private boolean premiumVanishHidden = false;
+    private int premiumVanishUseLevel = 0;
+    private int premiumVanishSeeLevel = 0;
+
+    public CorePlayer(CoreBackendServer lastKnownConnectedServer) {
+        this.lastKnownConnectedServer = lastKnownConnectedServer;
+    }
+
+    // Abstract
     @NotNull
-    UUID getUniqueId();
-
-    int getConnectionIdentity();
-
+    public abstract UUID getUniqueId();
+    public abstract int getConnectionIdentity();
     @Nullable
-    CoreBackendServer getCurrentServer();
-
-    @Nullable
-    CoreBackendServer getLastKnownConnectedServer();
-
-    void setLastKnownConnectedServer(CoreBackendServer server);
-
+    public abstract CoreBackendServer getCurrentServer();
     @NotNull
-    Audience getAudience();
-
-    boolean isInLimbo();
-
-    String getCachedLeaveMessage();
-    void setCachedLeaveMessage(String cachedLeaveMessage);
-
-    boolean isDisconnecting();
-    void setDisconnecting();
-
-    boolean getPremiumVanishHidden();
-    void setPremiumVanishHidden(boolean premiumVanishHidden);
-    int getPremiumVanishUseLevel();
-    void setPremiumVanishUseLevel(int level);
-    int getPremiumVanishSeeLevel();
-    void setPremiumVanishSeeLevel(int level);
+    public abstract Audience getAudience();
+    public abstract boolean isInLimbo();
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -101,7 +101,7 @@ public class CorePlayerListener {
             plugin.getCoreLogger().debug("Duplicate disconnect ignored for " + player.getName());
             return;
         }
-        player.setDisconnecting();
+        player.setDisconnecting(true);
 
         if (shouldSkipLeave(player)) {
             cleanup(player);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePremiumVanishListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePremiumVanishListener.java
@@ -22,7 +22,7 @@ public class CorePremiumVanishListener {
     }
 
     public void handlePremiumVanishShow(@NotNull CorePlayer player) {
-        if (!player.getPremiumVanishHidden()) return;
+        if (!player.isPremiumVanishHidden()) return;
         logger.debug("Setting PremiumVanishHidden to FALSE for " + player.getName());
         player.setPremiumVanishHidden(false);
         if (config.isPVSpoofJoinMessageOnShow() && !stateStore.getSilentState(player)) {
@@ -31,7 +31,7 @@ public class CorePremiumVanishListener {
     }
 
     public void handlePremiumVanishHide(@NotNull CorePlayer player) {
-        if (player.getPremiumVanishHidden()) return;
+        if (player.isPremiumVanishHidden()) return;
         logger.debug("Setting PremiumVanishHidden to TRUE for " + player.getName());
         player.setPremiumVanishHidden(true);
         if (config.isPVSpoofLeaveMessageOnHide() && !stateStore.getSilentState(player)) {

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/player/SilenceChecker.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/player/SilenceChecker.java
@@ -74,7 +74,7 @@ public final class SilenceChecker {
     private boolean isPremiumVanishSilent(CorePlayer player) {
         return premiumVanish != null
             && config.isPVTreatVanishedPlayersAsSilent()
-            && (premiumVanish.isVanished(player.getUniqueId()) || player.getPremiumVanishHidden());
+            && (premiumVanish.isVanished(player.getUniqueId()) || player.isPremiumVanishHidden());
     }
 
     private void logDebugState(CorePlayer player) {
@@ -88,7 +88,7 @@ public final class SilenceChecker {
             premiumVanish != null,
             config.isPVTreatVanishedPlayersAsSilent(),
             premiumVanish != null ? premiumVanish.isVanished(player.getUniqueId()) : "N/A",
-            player.getPremiumVanishHidden(),
+            player.isPremiumVanishHidden(),
             config.isPVTreatVanishedOnJoin(),
             player.hasPermission(PV_JOIN_VANISHED_PERM)
         ));

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/abstraction/VelocityPlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/abstraction/VelocityPlayer.java
@@ -13,21 +13,15 @@ import xyz.earthcow.networkjoinmessages.velocity.VelocityMain;
 
 import java.util.UUID;
 
-public class VelocityPlayer implements CorePlayer {
+public class VelocityPlayer extends CorePlayer {
     private final Player velocityPlayer;
-    private CoreBackendServer lastKnownConnectedServer;
     private final Audience audience;
-    private String cachedLeaveMessage;
-    private boolean disconnecting = false;
-    private boolean premiumVanishHidden = false;
-    private int pvUseLevel = 0;
-    private int pvSeeLevel = 0;
 
     public VelocityPlayer(Player velocityPlayer) {
+        super(velocityPlayer.getCurrentServer().isPresent() ?
+            new VelocityServer(velocityPlayer.getCurrentServer().get().getServer())
+            : null);
         this.velocityPlayer = velocityPlayer;
-        if (velocityPlayer.getCurrentServer().isPresent()) {
-            this.lastKnownConnectedServer = new VelocityServer(velocityPlayer.getCurrentServer().get().getServer());
-        }
         this.audience = Audience.audience(velocityPlayer);
     }
 
@@ -61,19 +55,9 @@ public class VelocityPlayer implements CorePlayer {
     public @Nullable CoreBackendServer getCurrentServer() {
         ServerConnection serverConnection = velocityPlayer.getCurrentServer().orElse(null);
         if (serverConnection == null) {
-            return lastKnownConnectedServer;
+            return getLastKnownConnectedServer();
         }
         return new VelocityServer(serverConnection.getServer());
-    }
-
-    @Override
-    public @Nullable CoreBackendServer getLastKnownConnectedServer() {
-        return lastKnownConnectedServer;
-    }
-
-    @Override
-    public void setLastKnownConnectedServer(CoreBackendServer server) {
-        lastKnownConnectedServer = server;
     }
 
     @Override
@@ -88,52 +72,5 @@ public class VelocityPlayer implements CorePlayer {
         }
         //noinspection ConstantValue
         return ((ConnectedPlayer) velocityPlayer).getConnection().getState().name() == null;
-    }
-
-    @Override
-    public String getCachedLeaveMessage() {
-        return cachedLeaveMessage;
-    }
-    @Override
-    public void setCachedLeaveMessage(String cachedLeaveMessage) {
-        this.cachedLeaveMessage = cachedLeaveMessage;
-    }
-
-    @Override
-    public boolean isDisconnecting() {
-        return disconnecting;
-    }
-
-    @Override
-    public void setDisconnecting() {
-        this.disconnecting = true;
-    }
-
-    @Override
-    public boolean getPremiumVanishHidden() {
-        return premiumVanishHidden;
-    }
-
-    @Override
-    public void setPremiumVanishHidden(boolean premiumVanishHidden) {
-        this.premiumVanishHidden = premiumVanishHidden;
-    }
-
-    @Override
-    public int getPremiumVanishUseLevel() {
-        return pvUseLevel;
-    }
-    @Override
-    public void setPremiumVanishUseLevel(int pvUseLevel) {
-        this.pvUseLevel = pvUseLevel;
-    }
-
-    @Override
-    public int getPremiumVanishSeeLevel() {
-        return pvSeeLevel;
-    }
-    @Override
-    public void setPremiumVanishSeeLevel(int pvSeeLevel) {
-        this.pvSeeLevel = pvSeeLevel;
     }
 }


### PR DESCRIPTION
This should've been done a while ago. `CorePlayer` and its implementations shared a lot of duplicate code and logic. This PR closes #55 and removes a lot of unnecessary code.

As a result of using Lombok for `CorePlayer`, `setDisconnecting` now requires a boolean argument and `getPremiumVanishHidden` was renamed to `isPremiumVanishHidden`. These changes are good for consistency and clarity anyway.