### PR TITLE
Ensure limbo plugin exists for fromLimbo

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
@@ -210,4 +210,9 @@ public class BungeeMain extends Plugin implements CorePlugin {
     public boolean isPluginLoaded(String pluginName) {
         return getProxy().getPluginManager().getPlugin(pluginName) != null;
     }
+
+    @Override
+    public boolean hasLimbo() {
+        return false;
+    }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
@@ -32,6 +32,7 @@ public interface CorePlugin {
     int runTaskAsyncLater(Runnable task, int timeInMillisecondsLater);
 
     boolean isPluginLoaded(String pluginName);
+    boolean hasLimbo();
 
     CoreCommandSender getConsole();
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -90,7 +90,7 @@ public class CorePlayerListener {
             if (!stateStore.isConnected(player)) {
                 handleJoin(player, server);
             } else {
-                boolean fromLimbo = plugin.getServerType() == ServerType.VELOCITY && previousServer == null;
+                boolean fromLimbo = plugin.hasLimbo() && previousServer == null;
                 handleSwap(player, server, fromLimbo);
             }
         });

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
@@ -225,6 +225,11 @@ public class VelocityMain implements CorePlugin {
     }
 
     @Override
+    public boolean hasLimbo() {
+        return isLimboAPIAvailable;
+    }
+
+    @Override
     public CorePlayer createPlayer(UUID uuid) {
         Optional<Player> player = proxy.getPlayer(uuid);
         return player.map(VelocityPlayer::new).orElse(null);


### PR DESCRIPTION
It's hypothetically possible for a player to be marked as `fromLimbo` due to some other underlying issue even whenever the player's server does not use a limbo plugin. Ensure that the server has a limbo plugin for `fromLimbo` to be true.