### PR TITLE
3.6.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project metadata
 group=xyz.earthcow.networkjoinmessages
-version=3.6.0
+version=3.6.1
 description=A plugin handling join, leave and swap messages for proxy servers.
 
 # Plugin.yml metadata

--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
@@ -210,4 +210,9 @@ public class BungeeMain extends Plugin implements CorePlugin {
     public boolean isPluginLoaded(String pluginName) {
         return getProxy().getPluginManager().getPlugin(pluginName) != null;
     }
+
+    @Override
+    public boolean hasLimbo() {
+        return false;
+    }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/MessageHandler.java
@@ -67,45 +67,25 @@ public final class MessageHandler {
 
     // --- Broadcast ---
 
-    /** Broadcasts a non-silent message using the player's current server as context. */
-    public void broadcastMessage(String text, MessageType type, CorePlayer parseTarget) {
-        broadcastMessage(text, type, parseTarget, false);
-    }
-
     /** Broadcasts a message using the player's current server as both from and to context. */
-    public void broadcastMessage(String text, MessageType type, CorePlayer parseTarget, boolean silent) {
-        broadcastMessage(text, type, parseTarget.getCurrentServer().getName(), "", parseTarget, silent);
-    }
-
-    /** Broadcasts a non-silent message with explicit server context. */
-    public void broadcastMessage(String text, MessageType type, String from, String to, CorePlayer parseTarget) {
-        broadcastMessage(text, type, from, to, parseTarget, false);
+    public void broadcastMessage(String text, MessageType type, CorePlayer parseTarget) {
+        broadcastMessage(text, type, parseTarget.getCurrentServer().getName(), "", parseTarget);
     }
 
     /**
      * Broadcasts a message to all appropriate recipients.
-     *
-     * <p>If {@code silent} is true, only the console and permission-holding admins receive it.
-     * Otherwise, all players who pass receiver, blacklist, and suppression checks are notified.
      *
      * @param text        the formatted message template
      * @param type        the message type (determines receiver list)
      * @param from        the origin server name
      * @param to          the destination server name
      * @param parseTarget the player to resolve placeholders against (may be null for leave messages)
-     * @param silent      whether this is a vanished/silent event
      */
     public void broadcastMessage(
             String text, MessageType type,
             String from, String to,
-            @NotNull CorePlayer parseTarget,
-            boolean silent
+            @Nullable CorePlayer parseTarget
     ) {
-        if (silent) {
-            broadcastSilentMessage(text, type, from, to, parseTarget, true);
-            return;
-        }
-
         List<CorePlayer> receivers = switch (type) {
             case SWAP       -> receiverResolver.getSwapReceivers(to, from);
             case FIRST_JOIN -> receiverResolver.getFirstJoinReceivers(from);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlugin.java
@@ -32,6 +32,7 @@ public interface CorePlugin {
     int runTaskAsyncLater(Runnable task, int timeInMillisecondsLater);
 
     boolean isPluginLoaded(String pluginName);
+    boolean hasLimbo();
 
     CoreCommandSender getConsole();
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -90,7 +90,7 @@ public class CorePlayerListener {
             if (!stateStore.isConnected(player)) {
                 handleJoin(player, server);
             } else {
-                boolean fromLimbo = plugin.getServerType() == ServerType.VELOCITY && previousServer == null;
+                boolean fromLimbo = plugin.hasLimbo() && previousServer == null;
                 handleSwap(player, server, fromLimbo);
             }
         });

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -150,7 +150,11 @@ public class CorePlayerListener {
             messageHandler.sendMessage(player, config.getSpoofJoinNotification());
         }
 
-        messageHandler.broadcastMessage(message, msgType, player, silent);
+        if (silent) {
+            messageHandler.broadcastSilentMessage(message, msgType, player.getCurrentServer().getName(), "", player, true);
+        } else {
+            messageHandler.broadcastMessage(message, msgType, player);
+        }
         fireJoinEvent(player, server, message, silent, firstJoin);
     }
 
@@ -166,7 +170,11 @@ public class CorePlayerListener {
         String message = messageFormatter.formatSwapMessage(player, from, to);
         boolean silent = silenceChecker.isSilent(player);
 
-        messageHandler.broadcastMessage(message, MessageType.SWAP, from, to, player, silent);
+        if (silent) {
+            messageHandler.broadcastSilentMessage(message, MessageType.SWAP, from, to, player, true);
+        } else {
+            messageHandler.broadcastMessage(message, MessageType.SWAP, from, to, player);
+        }
         fireSwapEvent(player, from, to, message, silent);
     }
 
@@ -175,8 +183,12 @@ public class CorePlayerListener {
         boolean silent = silenceChecker.isSilent(player);
         String serverName = player.getCurrentServer().getName();
 
-        // Pass player as triggerPlayer but false for isParseTarget as the placeholders are already resolved in cache
-        messageHandler.broadcastSilentMessage(message, MessageType.LEAVE, serverName, "", player, false);
+        if (silent) {
+            // Pass player as triggerPlayer but false for isParseTarget as the placeholders are already resolved in cache
+            messageHandler.broadcastSilentMessage(message, MessageType.LEAVE, serverName, "", player, false);
+        } else {
+            messageHandler.broadcastMessage(message, MessageType.LEAVE, serverName, "", null);
+        }
         fireLeaveEvent(player, serverName, message, silent);
     }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
@@ -225,6 +225,11 @@ public class VelocityMain implements CorePlugin {
     }
 
     @Override
+    public boolean hasLimbo() {
+        return isLimboAPIAvailable;
+    }
+
+    @Override
     public CorePlayer createPlayer(UUID uuid) {
         Optional<Player> player = proxy.getPlayer(uuid);
         return player.map(VelocityPlayer::new).orElse(null);


### PR DESCRIPTION
- Fixes a critical issue introduced in 3.6.0 (f4681e27ad35b0420e3a44b764cb00c3554156a3) causing leave messages to always be silent
- Ensures that a limbo plugin exists on the proxy for `fromLimbo` to be true