### PR TITLE
Add disconnect identity check debug logs & get CorePlayer directly

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/BungeeMain.java
@@ -75,7 +75,7 @@ public class BungeeMain extends Plugin implements CorePlugin {
 
         getProxy()
             .getPluginManager()
-            .registerListener(this, new PlayerListener(core.getCorePlayerListener()));
+            .registerListener(this, new PlayerListener(core.getCorePlayerListener(), bungeeLogger));
 
         getProxy()
             .getPluginManager()

--- a/src/main/java/xyz/earthcow/networkjoinmessages/bungee/listeners/PlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/bungee/listeners/PlayerListener.java
@@ -8,6 +8,7 @@ import net.md_5.bungee.api.event.ServerConnectedEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
 import xyz.earthcow.networkjoinmessages.bungee.BungeeMain;
+import xyz.earthcow.networkjoinmessages.bungee.abstraction.BungeeLogger;
 import xyz.earthcow.networkjoinmessages.bungee.abstraction.BungeePlayer;
 import xyz.earthcow.networkjoinmessages.bungee.abstraction.BungeeServer;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
@@ -16,9 +17,11 @@ import xyz.earthcow.networkjoinmessages.common.listeners.CorePlayerListener;
 public class PlayerListener implements Listener {
 
     private final CorePlayerListener corePlayerListener;
+    private final BungeeLogger logger;
 
-    public PlayerListener(CorePlayerListener corePlayerListener) {
+    public PlayerListener(CorePlayerListener corePlayerListener, BungeeLogger logger) {
         this.corePlayerListener = corePlayerListener;
+        this.logger = logger;
     }
 
     @EventHandler
@@ -42,8 +45,10 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onDisconnect(PlayerDisconnectEvent event) {
         // Check that the player disconnected is not a duplicate user session (the same account tries to join the server while already joined)
-        CorePlayer corePlayer = BungeeMain.getInstance().getOrPutPlayer(new BungeePlayer(event.getPlayer()));
-        if (corePlayer.getConnectionIdentity() != System.identityHashCode(event.getPlayer())) {
+        CorePlayer corePlayer = BungeeMain.getInstance().getPlayerManager().getPlayer(event.getPlayer().getUniqueId());
+        if (corePlayer == null || corePlayer.getConnectionIdentity() != System.identityHashCode(event.getPlayer())) {
+            logger.debug("Ignoring disconnect event for " + (corePlayer == null ? "null" : corePlayer.getName())
+                + " (" + event.getPlayer().getName() + ") - null or duplicate player identity");
             return;
         }
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/VelocityMain.java
@@ -106,7 +106,7 @@ public class VelocityMain implements CorePlugin {
             velocityLogger.info("Successfully hooked into PremiumVanish!");
         }
 
-        proxy.getEventManager().register(this, new PlayerListener(core.getCorePlayerListener()));
+        proxy.getEventManager().register(this, new PlayerListener(core.getCorePlayerListener(), velocityLogger));
 
         registerCommands();
 

--- a/src/main/java/xyz/earthcow/networkjoinmessages/velocity/listeners/PlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/velocity/listeners/PlayerListener.java
@@ -7,15 +7,18 @@ import com.velocitypowered.api.event.player.ServerPreConnectEvent;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
 import xyz.earthcow.networkjoinmessages.common.listeners.CorePlayerListener;
 import xyz.earthcow.networkjoinmessages.velocity.VelocityMain;
+import xyz.earthcow.networkjoinmessages.velocity.abstraction.VelocityLogger;
 import xyz.earthcow.networkjoinmessages.velocity.abstraction.VelocityPlayer;
 import xyz.earthcow.networkjoinmessages.velocity.abstraction.VelocityServer;
 
 public class PlayerListener {
 
     private final CorePlayerListener corePlayerListener;
+    private final VelocityLogger logger;
 
-    public PlayerListener(CorePlayerListener corePlayerListener) {
+    public PlayerListener(CorePlayerListener corePlayerListener, VelocityLogger logger) {
         this.corePlayerListener = corePlayerListener;
+        this.logger = logger;
     }
 
     @Subscribe
@@ -36,11 +39,12 @@ public class PlayerListener {
     @Subscribe
     public void onDisconnect(DisconnectEvent event) {
         // Check that the player disconnected is not a duplicate user session (the same account tries to join the server while already joined)
-        CorePlayer corePlayer = VelocityMain.getInstance().getOrPutPlayer(new VelocityPlayer(event.getPlayer()));
-        if (corePlayer.getConnectionIdentity() != System.identityHashCode(event.getPlayer())) {
+        CorePlayer corePlayer = VelocityMain.getInstance().getPlayerManager().getPlayer(event.getPlayer().getUniqueId());
+        if (corePlayer == null || corePlayer.getConnectionIdentity() != System.identityHashCode(event.getPlayer())) {
+            logger.debug("Ignoring disconnect event for " + (corePlayer == null ? "null" : corePlayer.getName())
+                + " (" + event.getPlayer().getUsername() + ") - null or duplicate player identity");
             return;
         }
-
         corePlayerListener.onDisconnect(corePlayer);
     }
 }


### PR DESCRIPTION
Get the `CorePlayer` directly from the `PlayerManager` instead of using `getOrPutPlayer` in the `DisconnectEvent`. This prevents pointlessly instantiating a new `CorePlayer` object.

Debug log when a `DisconnectEvent` is ignored due to a null or duplicate `CorePlayer`.