### PR TITLE
Move connected state into CorePlayer class

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 @Getter @Setter
 public abstract class CorePlayer implements CoreCommandSender {
     // Fields
+    private boolean connected = false;
     private CoreBackendServer lastKnownConnectedServer;
     private boolean disconnecting = false;
     private String cachedLeaveMessage;

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/listeners/CorePlayerListener.java
@@ -87,7 +87,7 @@ public class CorePlayerListener {
     public void onServerConnected(@NotNull CorePlayer player, @NotNull CoreBackendServer server,
                                    @Nullable CoreBackendServer previousServer) {
         plugin.runTaskAsync(() -> {
-            if (!stateStore.isConnected(player)) {
+            if (!player.isConnected()) {
                 handleJoin(player, server);
             } else {
                 boolean fromLimbo = plugin.hasLimbo() && previousServer == null;
@@ -119,7 +119,7 @@ public class CorePlayerListener {
 
     private void handleJoin(@NotNull CorePlayer player, @NotNull CoreBackendServer server) {
         stateStore.loadData(player.getUniqueId(), player.getName());
-        stateStore.setConnected(player, true);
+        player.setConnected(true);
         player.setLastKnownConnectedServer(server);
 
         PremiumVanish pv = plugin.getVanishAPI();
@@ -243,7 +243,7 @@ public class CorePlayerListener {
 
     private boolean shouldSkipLeave(CorePlayer player) {
         if (player.getCurrentServer() == null) return true;
-        if (!stateStore.isConnected(player)) {
+        if (!player.isConnected()) {
             plugin.getCoreLogger().debug("Skipping leave for " + player.getName() + " — not marked as connected");
             return true;
         }
@@ -306,7 +306,6 @@ public class CorePlayerListener {
 
     private void cleanup(CorePlayer player) {
         plugin.getPlayerManager().removePlayer(player.getUniqueId());
-        stateStore.setConnected(player, false);
         leaveMessageCache.stopFor(player);
     }
 }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/player/PlayerStateStore.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/player/PlayerStateStore.java
@@ -26,7 +26,6 @@ public final class PlayerStateStore {
 
     private final Map<UUID, String>  previousServer = new ConcurrentHashMap<>();
     private final Map<UUID, Boolean> silentState    = new ConcurrentHashMap<>();
-    private final Set<UUID> onlinePlayers  = ConcurrentHashMap.newKeySet();
     private final Set<UUID> noJoinMessage  = ConcurrentHashMap.newKeySet();
     private final Set<UUID> noLeaveMessage = ConcurrentHashMap.newKeySet();
     private final Set<UUID> noSwapMessage  = ConcurrentHashMap.newKeySet();
@@ -99,17 +98,6 @@ public final class PlayerStateStore {
             return false;
         }
         return null;
-    }
-
-    // --- Online tracking ---
-
-    public boolean isConnected(CorePlayer player) {
-        return onlinePlayers.contains(player.getUniqueId());
-    }
-
-    public void setConnected(CorePlayer player, boolean connected) {
-        if (connected) onlinePlayers.add(player.getUniqueId());
-        else           onlinePlayers.remove(player.getUniqueId());
     }
 
     // --- Previous server ---

--- a/src/test/java/xyz/earthcow/networkjoinmessages/common/player/PlayerStateStoreTest.java
+++ b/src/test/java/xyz/earthcow/networkjoinmessages/common/player/PlayerStateStoreTest.java
@@ -291,31 +291,6 @@ class PlayerStateStoreTest {
     }
 
     // -----------------------------------------------------------------------
-    // isConnected / setConnected
-    // -----------------------------------------------------------------------
-
-    @Test
-    void setConnected_true_marksPlayerOnline() {
-        PlayerStateStore stateStore = new PlayerStateStore(plugin, config, store);
-        stateStore.setConnected(player, true);
-        assertTrue(stateStore.isConnected(player));
-    }
-
-    @Test
-    void setConnected_false_marksPlayerOffline() {
-        PlayerStateStore stateStore = new PlayerStateStore(plugin, config, store);
-        stateStore.setConnected(player, true);
-        stateStore.setConnected(player, false);
-        assertFalse(stateStore.isConnected(player));
-    }
-
-    @Test
-    void isConnected_unknownPlayer_returnsFalse() {
-        PlayerStateStore stateStore = new PlayerStateStore(plugin, config, store);
-        assertFalse(stateStore.isConnected(player));
-    }
-
-    // -----------------------------------------------------------------------
     // getFrom / setFrom
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
Replaces `onlinePlayers` from `PlayerStateStore` with a `CorePlayer` `connected` field. This was changed to keep the connected state bound to the `CorePlayer` object lifecycle.