### PR TITLE
Add discord leave message cache

### DIFF
--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/Core.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/Core.java
@@ -84,14 +84,18 @@ public class Core {
         ReceiverResolver receiverResolver  = new ReceiverResolver(plugin, config, sayanVanishHook != null, premiumVanish != null);
         MessageHandler   messageHandler    = new MessageHandler(plugin, config, stateStore, placeholderResolver, receiverResolver);
 
+        // Discord webhook builder, early for leave message cache usage
+        DiscordWebhookBuilder webhookBuilder = new DiscordWebhookBuilder(plugin, configManager.getDiscordConfig());
+
         // Player event helpers
         SilenceChecker         silenceChecker    = new SilenceChecker(plugin, config, stateStore, sayanVanishHook, premiumVanish);
-        LeaveMessageCache      leaveMessageCache = new LeaveMessageCache(plugin, config, messageFormatter, placeholderResolver);
+        LeaveMessageCache      leaveMessageCache = new LeaveMessageCache(
+            plugin, config, messageFormatter, placeholderResolver, webhookBuilder, configManager.getDiscordConfig());
         LeaveJoinBufferManager leaveJoinBuffer   = new LeaveJoinBufferManager(plugin, config);
 
         // Discord integration
-        DiscordWebhookBuilder  webhookBuilder      = new DiscordWebhookBuilder(plugin, configManager.getDiscordConfig());
-        DiscordIntegration     discordIntegration  = new DiscordIntegration(plugin, placeholderResolver, messageFormatter, webhookBuilder, configManager.getDiscordConfig());
+        DiscordIntegration discordIntegration = new DiscordIntegration(
+            plugin, placeholderResolver, messageFormatter, webhookBuilder, configManager.getDiscordConfig());
 
         // Spoof
         SpoofManager spoofManager = new SpoofManager(plugin, config, messageHandler, messageFormatter, placeholderResolver);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/abstraction/CorePlayer.java
@@ -19,6 +19,7 @@ public abstract class CorePlayer implements CoreCommandSender {
     @Getter(AccessLevel.NONE) @Setter(AccessLevel.NONE)
     private AtomicBoolean disconnecting = new AtomicBoolean(false);
     private String cachedLeaveMessage;
+    private String cachedDiscordLeavePayload;
     private Audience audience;
     private boolean premiumVanishHidden = false;
     private int premiumVanishUseLevel = 0;

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordIntegration.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordIntegration.java
@@ -71,7 +71,7 @@ public class DiscordIntegration {
         DiscordWebhook webhook = webhookBuilder.buildSwapWebhook(webhookUrl);
         if (webhook == null) return;
 
-        String avatarUrl = resolveAvatarUrl(player);
+        String avatarUrl = webhookBuilder.resolveAvatarUrl(player);
         String preparedJson = messageFormatter.prepareDiscordSwapTemplate(
             webhook.getJsonString(), player, event.serverFrom(), event.serverTo(), avatarUrl);
         executeWebhook(webhook, preparedJson, player);
@@ -84,7 +84,7 @@ public class DiscordIntegration {
         DiscordWebhook webhook = webhookBuilder.buildJoinWebhook(webhookUrl, key);
         if (webhook == null) return;
 
-        String avatarUrl = resolveAvatarUrl(player);
+        String avatarUrl = webhookBuilder.resolveAvatarUrl(player);
         String preparedJson = messageFormatter.prepareDiscordJoinLeaveTemplate(
             webhook.getJsonString(), player, false, avatarUrl);
         executeWebhook(webhook, preparedJson, player);
@@ -96,10 +96,13 @@ public class DiscordIntegration {
         DiscordWebhook webhook = webhookBuilder.buildLeaveWebhook(webhookUrl);
         if (webhook == null) return;
 
-        String avatarUrl = resolveAvatarUrl(player);
-        String preparedJson = messageFormatter.prepareDiscordJoinLeaveTemplate(
-            webhook.getJsonString(), player, true, avatarUrl);
-        executeWebhook(webhook, preparedJson, player);
+        String cachedPayload = player.getCachedDiscordLeavePayload();
+        if (cachedPayload == null) {
+            plugin.getCoreLogger().warn(
+                "No cached Discord leave payload for " + player.getName() + ", skipping webhook.");
+            return;
+        }
+        sendWebhook(webhook, cachedPayload);
     }
 
     // --- Webhook execution ---
@@ -109,27 +112,20 @@ public class DiscordIntegration {
      * string, then executes the webhook asynchronously.
      */
     private void executeWebhook(DiscordWebhook webhook, String preparedJson, CorePlayer parseTarget) {
-        placeholderResolver.resolve(preparedJson, parseTarget, fullyResolved ->
-            plugin.runTaskAsync(() -> {
-                try {
-                    webhook.execute(fullyResolved);
-                } catch (IOException e) {
-                    plugin.getCoreLogger().severe("[DiscordIntegration] " + describeHttpError(e));
-                    plugin.getCoreLogger().debug("Exception: " + e);
-                    plugin.getCoreLogger().debug("Webhook payload: " + preparedJson);
-                }
-            })
-        );
+        placeholderResolver.resolve(preparedJson, parseTarget, fullyResolved -> sendWebhook(webhook, fullyResolved));
     }
 
-    /**
-     * Resolves the avatar URL template from config, substituting {@code %uuid%} and
-     * {@code %player%} for the given player.
-     */
-    private String resolveAvatarUrl(CorePlayer player) {
-        return discordConfig.getString("EmbedAvatarUrl")
-            .replace("%uuid%", player.getUniqueId().toString())
-            .replace("%player%", player.getName());
+    /** Sends an already fully-resolved JSON payload to Discord asynchronously. */
+    private void sendWebhook(DiscordWebhook webhook, String fullyResolved) {
+        plugin.runTaskAsync(() -> {
+            try {
+                webhook.execute(fullyResolved);
+            } catch (IOException e) {
+                plugin.getCoreLogger().severe("[DiscordIntegration] " + describeHttpError(e));
+                plugin.getCoreLogger().debug("Exception: " + e);
+                plugin.getCoreLogger().debug("Webhook payload: " + fullyResolved);
+            }
+        });
     }
 
     /** Produces a human-readable error description for a failed webhook HTTP request. */

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordIntegration.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordIntegration.java
@@ -8,6 +8,7 @@ import xyz.earthcow.networkjoinmessages.common.broadcast.MessageFormatter;
 import xyz.earthcow.networkjoinmessages.common.events.NetworkJoinEvent;
 import xyz.earthcow.networkjoinmessages.common.events.NetworkLeaveEvent;
 import xyz.earthcow.networkjoinmessages.common.events.SwapServerEvent;
+import xyz.earthcow.networkjoinmessages.common.util.Formatter;
 import xyz.earthcow.networkjoinmessages.common.util.PlaceholderResolver;
 
 import java.io.FileNotFoundException;
@@ -118,12 +119,13 @@ public class DiscordIntegration {
     /** Sends an already fully-resolved JSON payload to Discord asynchronously. */
     private void sendWebhook(DiscordWebhook webhook, String fullyResolved) {
         plugin.runTaskAsync(() -> {
+            String cleanFullyResolved = Formatter.sanitize(fullyResolved);
             try {
-                webhook.execute(fullyResolved);
+                webhook.execute(cleanFullyResolved);
             } catch (IOException e) {
                 plugin.getCoreLogger().severe("[DiscordIntegration] " + describeHttpError(e));
                 plugin.getCoreLogger().debug("Exception: " + e);
-                plugin.getCoreLogger().debug("Webhook payload: " + fullyResolved);
+                plugin.getCoreLogger().debug("Webhook payload: " + cleanFullyResolved);
             }
         });
     }

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordWebhookBuilder.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/modules/DiscordWebhookBuilder.java
@@ -3,6 +3,7 @@ package xyz.earthcow.networkjoinmessages.common.modules;
 import dev.dejvokep.boostedyaml.YamlDocument;
 import org.jetbrains.annotations.Nullable;
 import xyz.earthcow.discordwebhook.DiscordWebhook;
+import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlugin;
 
 import java.awt.*;
@@ -52,6 +53,16 @@ public final class DiscordWebhookBuilder {
     @Nullable
     public DiscordWebhook buildLeaveWebhook(String webhookUrl) {
         return buildWebhook(webhookUrl, "Messages.LeaveNetwork");
+    }
+
+    /**
+     * Resolves the avatar URL template from config, substituting {@code %uuid%} and
+     * {@code %player%} for the given player.
+     */
+    public String resolveAvatarUrl(CorePlayer player) {
+        return discordConfig.getString("EmbedAvatarUrl")
+            .replace("%uuid%", player.getUniqueId().toString())
+            .replace("%player%", player.getName());
     }
 
     // --- Internal builder ---

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/player/LeaveMessageCache.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/player/LeaveMessageCache.java
@@ -79,7 +79,6 @@ public final class LeaveMessageCache {
 
     /** Forces an immediate refresh of the cached leave message for the given player. */
     public void refresh(CorePlayer player) {
-        plugin.getCoreLogger().debug("Refreshing cached leave message for " + player.getName());
         String template = messageFormatter.formatLeaveMessage(player);
         placeholderResolver.resolve(template, player, player::setCachedLeaveMessage);
         refreshDiscordPayload(player);

--- a/src/main/java/xyz/earthcow/networkjoinmessages/common/player/LeaveMessageCache.java
+++ b/src/main/java/xyz/earthcow/networkjoinmessages/common/player/LeaveMessageCache.java
@@ -1,9 +1,12 @@
 package xyz.earthcow.networkjoinmessages.common.player;
 
+import dev.dejvokep.boostedyaml.YamlDocument;
+import xyz.earthcow.discordwebhook.DiscordWebhook;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlayer;
 import xyz.earthcow.networkjoinmessages.common.abstraction.CorePlugin;
 import xyz.earthcow.networkjoinmessages.common.broadcast.MessageFormatter;
 import xyz.earthcow.networkjoinmessages.common.config.PluginConfig;
+import xyz.earthcow.networkjoinmessages.common.modules.DiscordWebhookBuilder;
 import xyz.earthcow.networkjoinmessages.common.util.PlaceholderResolver;
 
 import java.util.Map;
@@ -11,11 +14,14 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Pre-computes and caches the formatted leave message for each online player.
+ * Pre-computes and caches the formatted leave message for each online player, both for the
+ * in-game leave message and the Discord leave webhook payload.
  *
  * <p>Because a player's leave message cannot be computed after disconnect (no live
  * placeholder data), it is formatted periodically while the player is connected and
- * stored on the player object, ready to be sent immediately on disconnect.
+ * stored on the player object, ready to be sent immediately on disconnect. Both caches
+ * are refreshed together on the same timer so they can never fall out of sync with
+ * each other.
  */
 public final class LeaveMessageCache {
 
@@ -23,6 +29,8 @@ public final class LeaveMessageCache {
     private final PluginConfig config;
     private final MessageFormatter messageFormatter;
     private final PlaceholderResolver placeholderResolver;
+    private final DiscordWebhookBuilder discordWebhookBuilder;
+    private final YamlDocument discordConfig;
 
     /** Maps player UUID -> repeating cache-refresh task ID */
     private final Map<UUID, Integer> refreshTasks = new ConcurrentHashMap<>();
@@ -31,12 +39,16 @@ public final class LeaveMessageCache {
             CorePlugin plugin,
             PluginConfig config,
             MessageFormatter messageFormatter,
-            PlaceholderResolver placeholderResolver
+            PlaceholderResolver placeholderResolver,
+            DiscordWebhookBuilder discordWebhookBuilder,
+            YamlDocument discordConfig
     ) {
         this.plugin = plugin;
         this.config = config;
         this.messageFormatter = messageFormatter;
         this.placeholderResolver = placeholderResolver;
+        this.discordWebhookBuilder = discordWebhookBuilder;
+        this.discordConfig = discordConfig;
     }
 
     /** Starts cache-refresh tasks for all currently online players. Called on reload. */
@@ -70,5 +82,23 @@ public final class LeaveMessageCache {
         plugin.getCoreLogger().debug("Refreshing cached leave message for " + player.getName());
         String template = messageFormatter.formatLeaveMessage(player);
         placeholderResolver.resolve(template, player, player::setCachedLeaveMessage);
+        refreshDiscordPayload(player);
+    }
+
+    private void refreshDiscordPayload(CorePlayer player) {
+        if (!discordConfig.getBoolean("Enabled")) {
+            player.setCachedDiscordLeavePayload(null);
+            return;
+        }
+        String webhookUrl = discordConfig.getString("WebhookUrl");
+        DiscordWebhook webhook = discordWebhookBuilder.buildLeaveWebhook(webhookUrl);
+        if (webhook == null) {
+            player.setCachedDiscordLeavePayload(null);
+            return;
+        }
+        String avatarUrl = discordWebhookBuilder.resolveAvatarUrl(player);
+        String preparedJson = messageFormatter.prepareDiscordJoinLeaveTemplate(
+            webhook.getJsonString(), player, true, avatarUrl);
+        placeholderResolver.resolve(preparedJson, player, player::setCachedDiscordLeavePayload);
     }
 }


### PR DESCRIPTION
Adds a discord leave message cache which refreshes alongside the in-game leave message. Also removes the debug line for leave message cache refreshing and implemented color code / format stripping of all discord messages.

Closes #72